### PR TITLE
Re-enabled comments in the generated output.

### DIFF
--- a/AST/comments.dart
+++ b/AST/comments.dart
@@ -2,7 +2,6 @@ import 'package:analyzer/dart/element/element.dart';
 
 class Comments {
   static void appendComment(StringBuffer buffer, Element element) {
-    return;
     var dartComment = element.documentationComment;
     if (dartComment == null || dartComment == "") return;
 


### PR DESCRIPTION
Seems to work fine. Looks like it was disabled because it takes a bit longer to generate the output but I'm ok with it taking longer. Prefer to have the comments!

Implements: https://github.com/JeroMiya/xamarin.flutter/issues/7